### PR TITLE
Update build and deploy instructions to add steps to install and configure Sake

### DIFF
--- a/.dist.env
+++ b/.dist.env
@@ -15,3 +15,9 @@ INTEGRATION_DB_HOST="localhost"
 INTEGRATION_DB_USER="root"
 INTEGRATION_DB_PASSWORD="root"
 INTEGRATION_TABLE_PREFIX="wp_"
+
+# Sake environment variables
+GITHUB_USERNAME="your-github-username"
+GITHUB_API_KEY="github-personal-access-token" # https://github.com/settings/tokens/new?scopes=gist,repo,user&description=Facebook+for+WooCommerce+Deployments
+WP_SVN_USER=
+SAKE_PRE_RELEASE_PATH=


### PR DESCRIPTION
# Summary

Includes changes for the [Build & Release](https://github.com/facebookincubator/facebook-for-woocommerce/wiki/Build-&-Release) wiki page to add steps to install and configure Sake.

Also updates the example environment variables file to include the variable necessary to use `sake` to deploy new versions of the plugin.



### Story: [CH 1234](story-url)

## Details

I believe it would be good to update the **Deploy** section in https://github.com/facebookincubator/facebook-for-woocommerce/wiki/Build-&-Release#deploy with the content below. Since I don't have write access to the repo anymore, I'll leave the content as a suggestion here:

---

## Deploy

Facebook for WooCommerce uses Sake to build assets and deploy new versions. You can check the [Getting started](https://github.com/skyverge/sake/wiki/Getting-started) page for installation instructions.

### Environment configuration

Once Sake is installed, you'll have to set a value for the following environment variables. Make sure to copy `.env.dist` to `.env` and provide a value.

- `GITHUB_USERNAME`: your GitHub username
-  `GITHUB_API_KEY`: used to access the GitHub API to retrieve information about the repository and to create releases automatically. These can be [generated on the Applications settings page](https://github.com/settings/tokens/new?scopes=gist,repo,user&description=Facebook+for+WooCommerce+Deployments).
- `WP_SVN_USER`: the username of a WordPress.org user with permissions to commit changes to https://plugins.svn.wordpress.org/facebook-for-woocommerce/. Sake will ask for the password the first time that the user attempts to commit.
- `SAKE_PRE_RELEASE_PATH`: a path to a directory where the zip files generated with `sake prerelease` should be stored (e.g. `~/Projects/prereleases`)

You can also define these variables as shell environment variables in your `.bash_profile` (or `.zprofile` if you use zsh).

### Deploy via Sake

Run `composer install --no-dev` as a sanity check to confirm that your vendor directory is clean. It doesn't hurt if you want remove the `vendor` directory entirely and let Sake create it again during the deploy process.

Then, deploy the new version with:

```
npx sake deploy --deployAssets=0
```

Check the [Configuration](https://github.com/skyverge/sake/wiki/Configuration) and [CLI Options](https://github.com/skyverge/sake/wiki/CLI-options) pages to learn more about how to control Sake.

---

## QA

### Setup

1. Create a fork of the [Facebook for WooCommerce repo](https://github.com/facebookincubator/facebook-for-woocommerce/) (we'll call that one the **development** repo)
2. Create a [local SVN repository](https://github.com/skyverge/sake/wiki/Testing#create-a-local-svn-repository) to be used as the **production** repo
3. Clone the development repo in your machine
4. Run `npm install`
5. Copy `.env.dist` to `.env` and add the environment variables from this PR and appropriate values
4. Update `sake.config.js` as follows, replacing the path to the SVN repo:
    ```
    module.exports = {
      plugin: {
        id: 'facebook-for-woocommerce'
      },
      deploy: {
        type: 'wp',
        production: 'file:///path/to/repo'
      },
      framework: 'v5',
      deployAssets: false
    };
    ```
5. Commit the changes to `sake.config.js`
6. Prepare the plugin for deploy (bump the development version as in the [**Before deploy** instructions](https://github.com/facebookincubator/facebook-for-woocommerce/wiki/Build-&-Release#deploy)) and commit the changes

### Steps

7. Run `npx sake deploy` to deploy a new version of the plugin
    - [ ] The tasks are completed without errors
    - [ ] A release was created in the development repo
    - [ ] Changes were committed to the local SVN repo